### PR TITLE
Gitignore only files that actually exist in this repo.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,18 +1,1 @@
-*.gem
-*.rbc
-.bundle
-.config
-coverage
-InstalledFiles
-lib/bundler/man
-pkg
-rdoc
-spec/reports
-test/tmp
-test/version_tmp
-tmp
-
-# YARD artifacts
-.yardoc
-_yardoc
-doc/
+Gemfile.lock


### PR DESCRIPTION
This was probably a copy paste. None of these things exist in the `money_helper` gem. On the other hand, gitignoring Gemfile.lock is a good idea, this way tests would run against the latest versions of compatible gems.
