### PR TITLE
Relax dependency on ActiveSupport 3.x.

### DIFF
--- a/money_helper.gemspec
+++ b/money_helper.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |s|
   s.test_files  = Dir['spec/*.rb']
   s.homepage    = 'https://github.com/syakhmi/money_helper'
   s.add_dependency('money', '~> 5.1.1')
-  s.add_dependency('activesupport', '~> 3.2')
+  s.add_dependency('activesupport', '>= 3.0')
   s.add_development_dependency('rspec')
   s.licenses = ['MIT']
 end


### PR DESCRIPTION
Gem works fine with ActiveSupport 4.x, which ships with Rails 4.
