### PR TITLE
@syakhmi => Some minor additions

### DIFF
--- a/lib/money_helper.rb
+++ b/lib/money_helper.rb
@@ -25,19 +25,16 @@ module MoneyHelper
   #   currency: (String)
   #   number_only: (Boolean) optional flag to exclude currency indicators (retains number formatting
   #     specific to currency)
-  def self.money_to_text(amount, currency, number_only = false)
+  def self.money_to_text(amount, currency, number_only = false, options = {})
     return nil unless amount.present?
     currency = "USD" if currency.blank?
     valid_currency = code_valid?(currency) ? currency : "USD"
     symbol = symbol_for_code(currency)
     include_symbol = !number_only && symbol.present? && OK_SYMBOLS.include?(symbol)
     subunit_factor = Money::Currency.new(valid_currency).subunit_to_unit
+    money_options = { no_cents: true, symbol_position: :before, symbol: include_symbol }.merge(options)
     (number_only || SYMBOL_ONLY.include?(currency) ? "" : currency + " ") +
-      Money.new(amount*subunit_factor.ceil, valid_currency).format({
-        no_cents: true,
-        symbol_position: :before,
-        symbol: include_symbol
-      }).delete(' ')
+      Money.new(amount*subunit_factor.ceil, valid_currency).format(money_options).delete(' ')
   end
 
   ##

--- a/lib/money_helper.rb
+++ b/lib/money_helper.rb
@@ -37,6 +37,17 @@ module MoneyHelper
       Money.new(amount*subunit_factor.ceil, valid_currency).format(money_options).delete(' ')
   end
 
+  def self.symbol_with_optional_iso_code(currency = 'USD')
+    symbol = symbol_for_code(currency)
+    if SYMBOL_ONLY.include?(currency)
+      symbol
+    elsif symbol
+      "#{iso_for_currency(currency)} #{symbol}"
+    else
+      "#{iso_for_currency(currency)}"
+    end
+  end
+
   ##
   # Formats a low and high amount in the given currency into a price string
   #
@@ -73,11 +84,17 @@ module MoneyHelper
     Money::Currency.stringified_keys.include?(code.downcase)
   end
 
+  def self.iso_for_currency(code)
+    return unless code && code_valid?(code)
+    Money::Currency.new(code).iso_code.tap do |iso_code|
+      iso_code.strip! if iso_code.present?
+    end
+  end
+
   def self.symbol_for_code(code)
     return unless code && code_valid?(code)
     Money::Currency.new(code).symbol.tap do |symbol|
       symbol.strip! if symbol.present?
     end
   end
-
 end

--- a/spec/money_helper_spec.rb
+++ b/spec/money_helper_spec.rb
@@ -145,6 +145,10 @@ describe MoneyHelper do
       expect(MoneyHelper.money_to_text(10_000, "ITL")).to eql("ITL 10,000")
       expect(MoneyHelper.money_to_text(10_000, "ITL", true)).to eql("10,000")
     end
+    it 'allows options to be passed through and cents displayed' do
+      expect(MoneyHelper.money_to_text(10_000.1, 'USD', nil, no_cents: false)).to eq '$10,000.10'
+      expect(MoneyHelper.money_to_text(10_000.1, 'USD')).to eq '$10,000'
+    end
   end
   describe "money_range_to_text" do
     it "includes no indicator for currency for the upper amount in range" do

--- a/spec/money_helper_spec.rb
+++ b/spec/money_helper_spec.rb
@@ -150,6 +150,19 @@ describe MoneyHelper do
       expect(MoneyHelper.money_to_text(10_000.1, 'USD')).to eq '$10,000'
     end
   end
+  describe 'symbol_with_optional_iso_code' do
+    it 'just includes the symbol for USD GBP EUR and MYR' do
+      expect(MoneyHelper.symbol_with_optional_iso_code("EUR")).to eql("€")
+      expect(MoneyHelper.symbol_with_optional_iso_code("GBP")).to eql("£")
+      expect(MoneyHelper.symbol_with_optional_iso_code("MYR")).to eql("RM")
+      expect(MoneyHelper.symbol_with_optional_iso_code("USD")).to eql("$")
+    end
+    it 'includes the iso code as well for other currencies' do
+      expect(MoneyHelper.symbol_with_optional_iso_code("AUD")).to eql("AUD $")
+      expect(MoneyHelper.symbol_with_optional_iso_code("UZS")).to eql("UZS")
+      expect(MoneyHelper.symbol_with_optional_iso_code("JPY")).to eql("JPY ¥")
+    end
+  end
   describe "money_range_to_text" do
     it "includes no indicator for currency for the upper amount in range" do
       expect(MoneyHelper.money_range_to_text(30000, 40000, "USD")).to eql("$30,000 - 40,000")


### PR DESCRIPTION
Hi!

We've added a couple minor things here, still happily in use in production!

We allow the underlying options that get passed to `Money.new` be specified (in some contexts we wanted cents, essentially), as well as a currency symbol to display string helper.

Let me know if I should update any docs, thanks!
