### PR TITLE
Relexed ActiveSupport dependency.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+Next
+----
+* [#10](https://github.com/syakhmi/money_helper/pull/10): Relaxed activesupport version dependency - [@dblock](https://github.com/dblock).
+* [#8](https://github.com/syakhmi/money_helper/pull/8): The `money_to_text` method now takes options - [@mzikherman](https://github.com/mzikherman).
+* [#8](https://github.com/syakhmi/money_helper/pull/8): Added `symbol_with_optional_iso_code` - [@mzikherman](https://github.com/mzikherman).
+
 1.0.0 (3/7/2015)
 ------------
 * Added compatibility with Money 6.5.1+, including new currency symbols - [@syakhmi](https://github.com/syakhmi).

--- a/money_helper.gemspec
+++ b/money_helper.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |s|
   s.test_files  = Dir['spec/*.rb']
   s.homepage    = 'https://github.com/syakhmi/money_helper'
   s.add_dependency('money', '~> 6.5')
-  s.add_dependency('activesupport', '~> 4')
+  s.add_dependency('activesupport')
   s.add_development_dependency('rspec', '~> 3')
   s.licenses = ['MIT']
 end


### PR DESCRIPTION
No need to depend on ActiveSupport 4.x, works great with 5 and newer. The current .gemspec prevents this gem from being used with Rails 5 for example.