### PR TITLE
feat: Add format support to money range method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,12 @@
-### 3.0.1 (Next)
+### X.X.X (Next)
+
+* Your contribution here.
+### 3.0.2 (2023-03-22)
+
+* [#30](https://github.com/artsy/money_helper/pull/30): Update `money_range_to_text` to receive `format` parameter for optional formatting - [@leamotta](https://github.com/leamotta).
+### 3.0.1 (2023-03-21)
 
 * [#29](https://github.com/artsy/money_helper/pull/29): Update `money_range_to_text` to receive `with_currency` parameter for optional ISO code printing - [@leamotta](https://github.com/leamotta).
-* Your contribution here.
 
 ### 3.0.0 (2022-02-16)
 

--- a/lib/money_helper.rb
+++ b/lib/money_helper.rb
@@ -71,18 +71,21 @@ module MoneyHelper
   #   currency: (String) optional ISO currency code, defaulting to USD
   #   delimiter: (String) optional
   #   with_currency: (Boolean) optional flag to include ISO currency code, defaulting to true
-  def self.money_range_to_text(low, high, currency: 'USD', delimiter: ' - ', with_currency: true)
+  # 　format: (Hash) optional formatting options to pass to `Money#format` e.g.:
+  #     no_cents: (Boolean) optional flag to exclude cents, defaulting to false
+  #     symbol: (Boolean) optional flag to include currency symbol, defaulting to true
+  def self.money_range_to_text(low, high, currency: 'USD', delimiter: ' - ', with_currency: true, format: {})
     if low.blank? && high.blank?
       ''
     elsif low.blank?
-      "Under #{money_to_text(high, currency: currency, with_currency: with_currency)}"
+      "Under #{money_to_text(high, currency: currency, with_currency: with_currency, format: format)}"
     elsif high.blank?
-      "#{money_to_text(low, currency: currency, with_currency: with_currency)} and up"
+      "#{money_to_text(low, currency: currency, with_currency: with_currency, format: format)} and up"
     elsif low == high
-      money_to_text(low, currency: currency, with_currency: with_currency)
+      money_to_text(low, currency: currency, with_currency: with_currency, format: format)
     else
-      formatted_low = money_to_text(low, currency: currency, with_currency: with_currency)
-      formatted_high = money_to_text(high, currency: currency, with_currency: false, format: { symbol: false })
+      formatted_low = money_to_text(low, currency: currency, with_currency: with_currency, format: format)
+      formatted_high = money_to_text(high, currency: currency, with_currency: false, format: { symbol: false }.merge(format))
       [formatted_low, formatted_high].compact.join(delimiter)
     end
   end

--- a/lib/version.rb
+++ b/lib/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module MoneyHelper
-  VERSION = '3.0.1'
+  VERSION = '3.0.2'
 end

--- a/spec/money_helper_spec.rb
+++ b/spec/money_helper_spec.rb
@@ -235,6 +235,19 @@ describe MoneyHelper do
       expect(MoneyHelper.money_range_to_text(30_175_93, 40_983_27, currency: 'AMD', with_currency: false)).to eql('դր.30,175.93 - 40,983.27')
     end
 
+    it 'omits cents when `format: no_cents:` is true' do
+      expect(MoneyHelper.money_range_to_text(30_175_93, 40_983_27, with_currency: false, format: { no_cents: true })).to eql('$30,175 - 40,983')
+      expect(MoneyHelper.money_range_to_text(30_175_93, 40_983_27, currency: 'EUR', with_currency: false, format: { no_cents: true })).to eql('€30.175 - 40.983')
+      expect(MoneyHelper.money_range_to_text(30_175_93, 30_175_93, currency: 'EUR', with_currency: false, format: { no_cents: true })).to eql('€30.175')
+      expect(MoneyHelper.money_range_to_text(nil, 30_175_93, currency: 'EUR', with_currency: false, format: { no_cents: true })).to eql('Under €30.175')
+      expect(MoneyHelper.money_range_to_text(30_175_93, nil, currency: 'EUR', with_currency: false, format: { no_cents: true })).to eql('€30.175 and up')
+    end
+
+    it 'omits cents when `format: no_cents:` is true, omits symbol when `format: symbol:` is false' do
+      expect(MoneyHelper.money_range_to_text(30_175_93, 40_983_27, with_currency: false, format: { no_cents: true, symbol: false })).to eql('30,175 - 40,983')
+      expect(MoneyHelper.money_range_to_text(30_175_93, 40_983_27, currency: 'EUR', with_currency: false, format: { no_cents: true, symbol: false })).to eql('30.175 - 40.983')
+    end
+
     it "raises an exception when currency can't be found" do
       expect do
         MoneyHelper.money_range_to_text(10_000, 20_000, currency: 'ITL')


### PR DESCRIPTION
Currently there is no way to avoid printing cents whenever we use the `money_range_to_text` method. This PR adds that functionality.